### PR TITLE
意味論的強調表示(セマンティクスハイライト)

### DIFF
--- a/trunk/hspcmp/hsc3.h
+++ b/trunk/hspcmp/hsc3.h
@@ -49,7 +49,9 @@ public:
 	void SetCommonPath( char *path );
 
 	//		Service
-	int GetCmdList( int option );
+	int MoveCmdListToErrorBuf();
+	void GetCmdList( int option );
+	void GetCmdList( CToken* tk, int option );
 	int OpenPackfile( void );
 	void ClosePackfile( void );
 	void GetPackfileOption( char *out, char *keyword, char *defval );
@@ -60,6 +62,7 @@ public:
 
 	//		Data
 	//
+	CMemBuf *symbuf;
 	CMemBuf *errbuf;
 	CMemBuf *pfbuf;
 	CMemBuf *addkw;

--- a/trunk/hspcmp/label.cpp
+++ b/trunk/hspcmp/label.cpp
@@ -667,6 +667,9 @@ void CLabel::DumpHSPLabel( char *str, int option, int maxsize )
 		case LAB_TYPE_PPVAL:
 			if ( option & LAB_DUMPMODE_RESCMD ) typem = "sys|macro";
 			break;
+		case LAB_TYPE_VAR:
+			if ( option & LAB_DUMPMODE_RESCMD ) typem = "sys|var";
+			break;
 		default:
 			if ( option & LAB_DUMPMODE_RESCMD ) typem = "sys|func";
 			break;

--- a/trunk/hspcmp/label.h
+++ b/trunk/hspcmp/label.h
@@ -15,6 +15,7 @@
 #define def_maxlab 4096			// label object max (default)
 
 #define LAB_TYPE_MARK 0
+#define LAB_TYPE_VAR 1
 #define LAB_TYPE_SYSVAL 7
 #define LAB_TYPE_INTCMD 8
 #define LAB_TYPE_EXTCMD 9

--- a/trunk/hspcmp/token.cpp
+++ b/trunk/hspcmp/token.cpp
@@ -3669,6 +3669,10 @@ int CToken::LabelDump( CMemBuf *out, int option )
 {
 	//		“o˜^‚³‚ê‚Ä‚¢‚éƒ‰ƒxƒ‹î•ñ‚ğerrbuf‚É“WŠJ
 	//
+	if ( tmp_lb ) {
+		tmp_lb->DumpHSPLabel( linebuf, option, LINEBUF_MAX - 256 );
+		out->PutStr( linebuf );
+	}
 	lb->DumpHSPLabel( linebuf, option, LINEBUF_MAX - 256 );
 	out->PutStr( linebuf );
 	return 0;

--- a/trunk/hspcmp/win32dll/hspcmp3.cpp
+++ b/trunk/hspcmp/win32dll/hspcmp3.cpp
@@ -400,7 +400,8 @@ EXPORT BOOL WINAPI hsc3_getsym ( int p1, int p2, int p3, int p4 )
 {
 	//
 	//		hsc3_getsym val  (type1)
-	//
+	if ( hsc3->MoveCmdListToErrorBuf() == 0 ) { return 0; }
+
 	hsc3->ResetError();
 	if (orgcompath==0) {
 		GetModuleFileName( NULL,compath,_MAX_PATH );
@@ -408,8 +409,8 @@ EXPORT BOOL WINAPI hsc3_getsym ( int p1, int p2, int p3, int p4 )
 		strcat( compath,"common\\" );
 	}
 	hsc3->SetCommonPath( compath );
-	if ( hsc3->GetCmdList( p1|2 ) ) return -1;
-	return 0;
+	hsc3->GetCmdList( p1|2 );
+	return hsc3->MoveCmdListToErrorBuf();
 }
 
 

--- a/trunk/tools/win32/hsed3_footy2/Poppad.cpp
+++ b/trunk/tools/win32/hsed3_footy2/Poppad.cpp
@@ -470,6 +470,14 @@ static int GetFileTitle2( char *bname, char *tname )
 }
 
 
+static void onPostCompile()
+{
+	//		コンパイルの成功時に行う処理
+	UpdateClassify();
+	ResetClassify();
+}
+
+
 static void packgo( void )
 {
 	int a;
@@ -2331,6 +2339,7 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 #else
                         TMes("Object file generated.");
 #endif
+						onPostCompile();
 					}
 					return 0;
 
@@ -2345,6 +2354,7 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 #else
 					TMes("START.AX generated.");
 #endif
+					onPostCompile();
 					return 0;
 
 				case IDM_AUTOMAKE:
@@ -2358,6 +2368,7 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 #else
 					TMes("Executable file generated.");
 #endif
+					onPostCompile();
 					return 0;
 
 				case IDM_COMP:
@@ -2377,17 +2388,20 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 					}				
 					if (LOWORD (wParam)==IDM_COMP2) {
 						err_prt(hwnd);
+						onPostCompile();
 						return 0;
 					}	
 					if (LOWORD (wParam)==IDM_LOGCOMP) {
 						DialogBox (hInst, "Logcomp", hwnd, (DLGPROC)LogcompDlgProc );
 						if (hsp_logflag==0) return 0;
 						if (hsp_clmode==0) { hsprun_log("obj"); } else { hsprun_log_cl("obj"); }
+						onPostCompile();
 						return 0;
 					}
 
 				case IDM_RUN:
 					if (hsp_clmode==0) { hsprun("obj"); } else { hsprun_cl("obj"); }
+					onPostCompile();
 					return 0;
 
 				case IDM_COMP3:
@@ -2409,6 +2423,7 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 #else
 						TMes("Object file generated.");
 #endif
+						onPostCompile();
 						return 0;
 					}
 					strcpy( objname,"obj" );
@@ -2419,6 +2434,7 @@ LRESULT CALLBACK EditProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 					//a=tcomp_main( hsp_extstr, hsp_extstr, objname, errbuf,1 );
 					if (a) { err_prt(hwnd);return 0; }
 					if (hsp_clmode==0) { hsprun(objname); } else { hsprun_cl(objname); }
+					onPostCompile();
 					return 0;
 
 				case IDM_HSPERR:

--- a/trunk/tools/win32/hsed3_footy2/classify.cpp
+++ b/trunk/tools/win32/hsed3_footy2/classify.cpp
@@ -60,6 +60,7 @@ static TYPE_TABLE TypeTable[] = {
 	"sys|func",		&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
 	"sys|func|1",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
 	"sys|func|2",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
+	"sys|func|3",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
 	"pre|func",		&(color.Character.Preprocessor.Conf),	0,
 	NULL
 };
@@ -101,10 +102,6 @@ int TableCompare(const void *pTable1, const void *pTable2)
 
 void InitClassify()
 {
-	int bufsize;
-	char *buf, *line, name[256], type[256];
-
-	int nCTSize = 0;
 /*
 	FILE *fp = fopen("hsptmp", "w");
 	char last;
@@ -125,7 +122,18 @@ void InitClassify()
 	hsc_refname( 0,(int)(szTitleName[0] == '\0' ? "???" : szTitleName), 0,0 );
 	hsc_objname( 0,(int)"obj", 0,0 );
 	//hsc_comp( 1,1,0,0 );
-	hsc3_getsym(0, 0, 0, 0);
+	UpdateClassify();
+}
+
+void UpdateClassify()
+{
+	//		キーワードの色分け情報を登録する
+
+	int bufsize;
+	char *buf, *line, name[256], type[256];
+	int nCTSize = 0;
+
+	hsc3_getsym(0xF, 0, 0, 0);
 	hsc3_messize((int)&bufsize, 0, 0, 0);
 	buf = (char *)malloc(bufsize+1);
 	hsc_getmes((int)buf, 0, 0, 0);
@@ -183,6 +191,8 @@ void InitClassify()
 // 強調文字の設定
 void SetClassify(int FootyID)
 {
+	Footy2ClearEmphasis(FootyID);
+
 	// 2008-02-17 Shark++ 要動作確認
 	for(CLASSIFY_TABLE *lpCT = ClassifyTable; lpCT->Word1[0] != '\0'; lpCT++) {
 		Footy2AddEmphasis(FootyID, lpCT->Word1, *lpCT->Word2 ? lpCT->Word2 : NULL, lpCT->Type, 

--- a/trunk/tools/win32/hsed3_footy2/classify.cpp
+++ b/trunk/tools/win32/hsed3_footy2/classify.cpp
@@ -61,6 +61,7 @@ static TYPE_TABLE TypeTable[] = {
 	"sys|func|1",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
 	"sys|func|2",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
 	"sys|func|3",	&(color.Character.Function.Conf),		EMPFLAG_NON_CS,
+	"sys|var",      	&(color.Character.Var.Conf),			EMPFLAG_NON_CS,
 	"pre|func",		&(color.Character.Preprocessor.Conf),	0,
 	NULL
 };

--- a/trunk/tools/win32/hsed3_footy2/classify.h
+++ b/trunk/tools/win32/hsed3_footy2/classify.h
@@ -21,6 +21,7 @@ typedef struct tagMyColor{
 		MYCOLORREF Macro;
 		MYCOLORREF Comment;
 		MYCOLORREF Label;
+		MYCOLORREF Var;
 	} Character;
 
 	struct{
@@ -93,6 +94,7 @@ typedef struct tagClassifyTable{
 #define DEFCOLOR_PREPROCESSOR     RGB(  0, 255, 192)
 #define DEFCOLOR_STRING           RGB(255, 255, 192)
 #define DEFCOLOR_LABEL            RGB(255, 192, 214)
+#define DEFCOLOR_VAR              RGB(255, 214, 192)
 #define DEFCOLOR_LINENUM          RGB( 49, 117, 189)
 #define DEFCOLOR_MACRO            RGB(192, 255, 255)
 #define DEFCOLOR_RULER_FONT       RGB(  0,   0,   0)

--- a/trunk/tools/win32/hsed3_footy2/classify.h
+++ b/trunk/tools/win32/hsed3_footy2/classify.h
@@ -110,6 +110,7 @@ typedef struct tagClassifyTable{
 #define DEFCOLOR_RULER_DIVISION   RGB(  0,   0,   0)
 
 void InitClassify();
+void UpdateClassify();
 void SetClassify(int);
 void ResetClassify();
 void ByeClassify();

--- a/trunk/tools/win32/hsed3_footy2/config.cpp
+++ b/trunk/tools/win32/hsed3_footy2/config.cpp
@@ -213,6 +213,7 @@ void DefaultColor(MYCOLOR *dest)
 	dest->Character.Macro.Conf         = DEFCOLOR_MACRO;
 	dest->Character.Comment.Conf       = DEFCOLOR_COMMENT;
 	dest->Character.Label.Conf         = DEFCOLOR_LABEL;
+	dest->Character.Var.Conf           = DEFCOLOR_VAR;
 	dest->NonCharacter.HalfSpace.Conf  = DEFCOLOR_HALF_SPACE;
 	dest->NonCharacter.FullSpace.Conf  = DEFCOLOR_FULL_SPACE;
 	dest->NonCharacter.Tab.Conf        = DEFCOLOR_TAB;


### PR DESCRIPTION
コンパイラが収集したキーワードを下に色分け情報を更新する。
## 議論
- 健全さは望めない。
  - グローバル変数に #module 内部でも色がつくなど、キーワードの範囲をエディタが認識しない。
  - 特に引数エイリアスは無理
  - ユーザを混乱させる恐れもある。
- 実行速度
  - スクリプトが大きいとシンボル表の解析に時間がかかる。
## オレンジ色のマイルストーン
- [x] シンボルリストで色分け情報を更新する。
- [x] 変数に色を付ける。
- [ ] グローバル領域で定義された引数エイリアスは色分けしない。
- [x] 定義されなくなったキーワードの色は消えるようにする。
- [ ] `onPostCompile` はなるべく少なくすべき。
### 既知の不具合
- [x] プリプロセッサ命令が色分けされなくなる。
- [ ] キーワードの多いタブへの切り替えが重い。
- [x] ときどきF5に失敗する。
