### PR TITLE
配列拡張の高速化

### DIFF
--- a/trunk/hsp3/hspvar_core.cpp
+++ b/trunk/hsp3/hspvar_core.cpp
@@ -333,6 +333,46 @@ int HspVarCoreCountElems( PVal *pval )
 }
 
 
+void HspVarCoreAllocPODArray( PVal *pval, const PVal *pval2, int basesize )
+{
+	//		pval変数が必要とするサイズを確保する。
+	//		(pvalがすでに確保されているメモリ解放は呼び出し側が行なう)
+	//		(flagの設定は呼び出し側が行なう)
+	//		(pval2がNULLの場合は、新規データ)
+	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
+	//
+
+	// 配列を最低1は確保する
+	if ( pval->len[1] < 1 ) pval->len[1] = 1;
+
+	int size = HspVarCoreCountElems(pval) * basesize;
+	int old_size = (pval2 ? pval2->size : 0);
+
+	char *pt;
+	if ( pval == pval2 ) {
+		if ( size > STRBUF_BLOCKSIZE ) {
+			size = (size > old_size ? size + size / 8 : old_size);
+		}
+		pt = sbExpand(pval->pt, size);
+	} else {
+		pt = sbAlloc(size);
+
+		if ( pval2 != NULL ) {
+			memcpy(pt, pval2->pt, pval2->size);
+			sbFree(pval->pt);
+		}
+	}
+
+	// 新規要素を0埋め
+	if ( size > old_size ) {
+		memset(pt + old_size, 0, (size - old_size));
+	}
+
+	pval->pt = pt;
+	pval->size = size;
+	pval->mode = HSPVAR_MODE_MALLOC;
+}
+
 /*------------------------------------------------------------*/
 
 

--- a/trunk/hsp3/hspvar_core.cpp
+++ b/trunk/hsp3/hspvar_core.cpp
@@ -323,6 +323,16 @@ void HspVarCoreArray( PVal *pval, int offset )
 }
 
 
+int HspVarCoreCountElems( PVal *pval )
+{
+	int k = pval->len[1];
+	if ( pval->len[2] ) k *= pval->len[2];
+	if ( pval->len[3] ) k *= pval->len[3];
+	if ( pval->len[4] ) k *= pval->len[4];
+	return k;
+}
+
+
 /*------------------------------------------------------------*/
 
 

--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -217,6 +217,7 @@ void *HspVarCoreCnvPtr( PVal *pval, int flag );
 PDAT *HspVarCorePtrAPTR( PVal *pv, APTR ofs );
 void HspVarCoreArray( PVal *pval, int offset );
 int  HspVarCoreCountElems( PVal *pval );
+void HspVarCoreAllocPODArray( PVal *pval, const PVal *pval2, int basesize );
 
 //		macro for PVal
 //

--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -216,6 +216,7 @@ void HspVarCoreReDim( PVal *pval, int lenid, int len );
 void *HspVarCoreCnvPtr( PVal *pval, int flag );
 PDAT *HspVarCorePtrAPTR( PVal *pv, APTR ofs );
 void HspVarCoreArray( PVal *pval, int offset );
+int  HspVarCoreCountElems( PVal *pval );
 
 //		macro for PVal
 //

--- a/trunk/hsp3/hspvar_double.cpp
+++ b/trunk/hsp3/hspvar_double.cpp
@@ -82,48 +82,7 @@ static void HspVarDouble_Free( PVal *pval )
 
 static void HspVarDouble_Alloc( PVal *pval, const PVal *pval2 )
 {
-	//		pval変数が必要とするサイズを確保する。
-	//		(pvalがすでに確保されているメモリ解放は呼び出し側が行なう)
-	//		(flagの設定は呼び出し側が行なう)
-	//		(pval2がNULLの場合は、新規データ)
-	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
-	//
-	int size;
-	char *pt;
-	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
-	size = GetVarSize( pval );
-
-	int old_size;
-	if ( pval == pval2 ) {
-		old_size = pval2->size;
-		if ( size > STRBUF_BLOCKSIZE ) {
-			size = (size > old_size ? size + size / 8 : old_size);
-		}
-		pt = sbExpand(pval->pt, size);
-	} else {
-		pt = sbAlloc(size);
-
-		if ( pval2 == NULL ) {
-			old_size = 0;
-		} else {
-			old_size = pval2->size;
-			memcpy(pt, pval2->pt, pval2->size);
-			sbFree(pval->pt);
-		}
-	}
-
-	// 新規要素を初期化
-	if ( size > old_size ) {
-		double *fv = (double *)pt;
-		double *fv_end = fv + (size - old_size) / sizeof(double);
-		for ( ; fv != fv_end; fv ++ ) {
-			*fv = 0.0;
-		}
-	}
-
-	pval->pt = pt;
-	pval->size = size;
-	pval->mode = HSPVAR_MODE_MALLOC;
+	HspVarCoreAllocPODArray(pval, pval2, sizeof(double));
 }
 
 /*

--- a/trunk/hsp3/hspvar_double.cpp
+++ b/trunk/hsp3/hspvar_double.cpp
@@ -66,13 +66,7 @@ static int GetVarSize( PVal *pval )
 	//		PVALポインタの変数が必要とするサイズを取得する
 	//		(sizeフィールドに設定される)
 	//
-	int size;
-	size = pval->len[1];
-	if ( pval->len[2] ) size*=pval->len[2];
-	if ( pval->len[3] ) size*=pval->len[3];
-	if ( pval->len[4] ) size*=pval->len[4];
-	size *= sizeof(double);
-	return size;
+	return HspVarCoreCountElems(pval) * sizeof(double);
 }
 
 

--- a/trunk/hsp3/hspvar_double.cpp
+++ b/trunk/hsp3/hspvar_double.cpp
@@ -94,21 +94,42 @@ static void HspVarDouble_Alloc( PVal *pval, const PVal *pval2 )
 	//		(pval2がNULLの場合は、新規データ)
 	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
 	//
-	int i,size;
+	int size;
 	char *pt;
-	double *fv;
 	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
 	size = GetVarSize( pval );
-	pval->mode = HSPVAR_MODE_MALLOC;
-	pt = sbAlloc( size );
-	fv = (double *)pt;
-	for(i=0;i<(int)(size/sizeof(double));i++) { fv[i]=0.0; }
-	if ( pval2 != NULL ) {
-		memcpy( pt, pval->pt, pval->size );
-		sbFree( pval->pt );
+
+	int old_size;
+	if ( pval == pval2 ) {
+		old_size = pval2->size;
+		if ( size > STRBUF_BLOCKSIZE ) {
+			size = (size > old_size ? size + size / 8 : old_size);
+		}
+		pt = sbExpand(pval->pt, size);
+	} else {
+		pt = sbAlloc(size);
+
+		if ( pval2 == NULL ) {
+			old_size = 0;
+		} else {
+			old_size = pval2->size;
+			memcpy(pt, pval2->pt, pval2->size);
+			sbFree(pval->pt);
+		}
 	}
+
+	// 新規要素を初期化
+	if ( size > old_size ) {
+		double *fv = (double *)pt;
+		double *fv_end = fv + (size - old_size) / sizeof(double);
+		for ( ; fv != fv_end; fv ++ ) {
+			*fv = 0.0;
+		}
+	}
+
 	pval->pt = pt;
 	pval->size = size;
+	pval->mode = HSPVAR_MODE_MALLOC;
 }
 
 /*

--- a/trunk/hsp3/hspvar_int.cpp
+++ b/trunk/hsp3/hspvar_int.cpp
@@ -73,13 +73,7 @@ static int GetVarSize( PVal *pval )
 	//		PVALポインタの変数が必要とするサイズを取得する
 	//		(sizeフィールドに設定される)
 	//
-	int size;
-	size = pval->len[1];
-	if ( pval->len[2] ) size*=pval->len[2];
-	if ( pval->len[3] ) size*=pval->len[3];
-	if ( pval->len[4] ) size*=pval->len[4];
-	size *= sizeof(int);
-	return size;
+	return HspVarCoreCountElems(pval) * sizeof(int);
 }
 
 

--- a/trunk/hsp3/hspvar_int.cpp
+++ b/trunk/hsp3/hspvar_int.cpp
@@ -94,38 +94,7 @@ static void HspVarInt_Alloc( PVal *pval, const PVal *pval2 )
 	//		(pval2がNULLの場合は、新規データ)
 	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
 	//
-	int size;
-	char *pt;
-	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
-	size = GetVarSize( pval );
-
-	int old_size;
-	if ( pval == pval2 ) {
-		old_size = pval2->size;
-		if ( size > STRBUF_BLOCKSIZE ) {
-			size = (size > old_size ? size + size / 8 : old_size);
-		}
-		pt = sbExpand(pval->pt, size);
-	} else {
-		pt = sbAlloc(size);
-
-		if ( pval2 == NULL ) {
-			old_size = 0;
-		} else {
-			old_size = pval2->size;
-			memcpy(pt, pval2->pt, pval2->size);
-			sbFree(pval->pt);
-		}
-	}
-
-	// 新規要素を初期化
-	if ( size > old_size ) {
-		memset(pt + old_size, 0, size - old_size);
-	}
-
-	pval->pt = pt;
-	pval->size = size;
-	pval->mode = HSPVAR_MODE_MALLOC;
+	HspVarCoreAllocPODArray(pval, pval2, sizeof(int));
 }
 
 /*

--- a/trunk/hsp3/hspvar_label.cpp
+++ b/trunk/hsp3/hspvar_label.cpp
@@ -34,13 +34,7 @@ static int GetVarSize( PVal *pval )
 	//		PVALポインタの変数が必要とするサイズを取得する
 	//		(sizeフィールドに設定される)
 	//
-	int size;
-	size = pval->len[1];
-	if ( pval->len[2] ) size*=pval->len[2];
-	if ( pval->len[3] ) size*=pval->len[3];
-	if ( pval->len[4] ) size*=pval->len[4];
-	size *= sizeof(HSPVAR_LABEL);
-	return size;
+	return HspVarCoreCountElems(pval) * sizeof(HSPVAR_LABEL);
 }
 
 

--- a/trunk/hsp3/hspvar_label.cpp
+++ b/trunk/hsp3/hspvar_label.cpp
@@ -56,21 +56,7 @@ static void HspVarLabel_Alloc( PVal *pval, const PVal *pval2 )
 	//		(pval2がNULLの場合は、新規データ)
 	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
 	//
-	int i,size;
-	char *pt;
-	HSPVAR_LABEL *fv;
-	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
-	size = GetVarSize( pval );
-	pval->mode = HSPVAR_MODE_MALLOC;
-	pt = sbAlloc( size );
-	fv = (HSPVAR_LABEL *)pt;
-	for(i=0;i<(int)(size/sizeof(HSPVAR_LABEL));i++) { fv[i]=NULL; }
-	if ( pval2 != NULL ) {
-		memcpy( pt, pval->pt, pval->size );
-		sbFree( pval->pt );
-	}
-	pval->pt = pt;
-	pval->size = size;
+	HspVarCoreAllocPODArray(pval, pval2, sizeof(HSPVAR_LABEL));
 }
 
 // Size

--- a/trunk/hsp3/hspvar_str.cpp
+++ b/trunk/hsp3/hspvar_str.cpp
@@ -85,13 +85,7 @@ static int GetVarSize( PVal *pval )
 {
 	//		PVALポインタの変数が必要とするサイズを取得する
 	//
-	int size;
-	size = pval->len[1];
-	if ( pval->len[2] ) size*=pval->len[2];
-	if ( pval->len[3] ) size*=pval->len[3];
-	if ( pval->len[4] ) size*=pval->len[4];
-	size *= sizeof(char *);
-	return size;
+	return HspVarCoreCountElems(pval) * sizeof(char *);
 }
 
 static void HspVarStr_Free( PVal *pval )

--- a/trunk/hsp3/hspvar_struct.cpp
+++ b/trunk/hsp3/hspvar_struct.cpp
@@ -78,32 +78,44 @@ static void HspVarStruct_Alloc( PVal *pval, const PVal *pval2 )
 	//		(pval2がNULLの場合は、新規データ)
 	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
 	//
-	int i,size;
+	int size;
 	char *pt;
 	FlexValue *fv;
 	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
-	pval->mode = HSPVAR_MODE_MALLOC;
-	size = sizeof(FlexValue) * pval->len[1];
-	pt = sbAlloc( size );
-	fv = (FlexValue *)pt;
-	for(i=0;i<pval->len[1];i++) {
+	size = pval->len[1] * sizeof(FlexValue);
 
-/*
-	rev 53
-	BT#113: dimtypeでstruct型(モジュール型)変数が不完全な状態で作成される
-	に対処。
-*/
+	int old_size;
+	if ( pval == pval2 ) {
+		old_size = pval2->size;
+		if ( size > STRBUF_BLOCKSIZE ) {
+			size = (size > old_size ? size + size / 8 : old_size);
+		}
+		pt = sbExpand(pval->pt, size);
+	} else {
+		pt = sbAlloc(size);
 
-		memset( fv, 0, sizeof( FlexValue ) );
-		fv->type = FLEXVAL_TYPE_NONE;
-		fv++;
+		if ( pval2 == NULL ) {
+			old_size = 0;
+		} else {
+			old_size = pval2->size;
+			memcpy(pt, pval2->pt, pval2->size);
+			sbFree(pval->pt);
+		}
 	}
-	if ( pval2 != NULL ) {
-		memcpy( pt, pval->pt, pval->size );
-		sbFree( pval->pt );
+
+	// 新規要素を初期化
+	if ( size > old_size ) {
+		memset(pt + old_size, 0, size - old_size);
+#if FLEXVAL_TYPE_NONE != 0
+		for ( int i = (old_size / sizeof(FlexValue)); i < pval->len[1]; ++i ) {
+			fv[i].type = FLEXVAL_TYPE_NONE;
+		}
+#endif
 	}
+
 	pval->pt = pt;
 	pval->size = size;
+	pval->mode = HSPVAR_MODE_MALLOC;
 }
 
 /*

--- a/trunk/hsp3/hspvar_struct.cpp
+++ b/trunk/hsp3/hspvar_struct.cpp
@@ -78,44 +78,9 @@ static void HspVarStruct_Alloc( PVal *pval, const PVal *pval2 )
 	//		(pval2がNULLの場合は、新規データ)
 	//		(pval2が指定されている場合は、pval2の内容を継承して再確保)
 	//
-	int size;
-	char *pt;
-	FlexValue *fv;
-	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低1は確保する
-	size = pval->len[1] * sizeof(FlexValue);
 
-	int old_size;
-	if ( pval == pval2 ) {
-		old_size = pval2->size;
-		if ( size > STRBUF_BLOCKSIZE ) {
-			size = (size > old_size ? size + size / 8 : old_size);
-		}
-		pt = sbExpand(pval->pt, size);
-	} else {
-		pt = sbAlloc(size);
-
-		if ( pval2 == NULL ) {
-			old_size = 0;
-		} else {
-			old_size = pval2->size;
-			memcpy(pt, pval2->pt, pval2->size);
-			sbFree(pval->pt);
-		}
-	}
-
-	// 新規要素を初期化
-	if ( size > old_size ) {
-		memset(pt + old_size, 0, size - old_size);
-#if FLEXVAL_TYPE_NONE != 0
-		for ( int i = (old_size / sizeof(FlexValue)); i < pval->len[1]; ++i ) {
-			fv[i].type = FLEXVAL_TYPE_NONE;
-		}
-#endif
-	}
-
-	pval->pt = pt;
-	pval->size = size;
-	pval->mode = HSPVAR_MODE_MALLOC;
+	// FLEXVAL_TYPE_NONE == 0 なので、0埋め初期化で問題ない
+	HspVarCoreAllocPODArray(pval, pval2, sizeof(FlexValue));
 }
 
 /*

--- a/trunk/hsp3/win32gui/hspvar_comobj.cpp
+++ b/trunk/hsp3/win32gui/hspvar_comobj.cpp
@@ -58,19 +58,6 @@ static void *HspVarComobj_CnvCustom( const void *buffer, int flag )
 	return (void *)buffer;
 }
 
-static int GetVarElememtCount( PVal *pval )
-{
-	//		変数の要素数を取得する
-	//
-	int count;
-	count = pval->len[1];
-	if ( pval->len[2] ) count *= pval->len[2];
-	if ( pval->len[3] ) count *= pval->len[3];
-	if ( pval->len[4] ) count *= pval->len[4];
-	return count;
-}
-
-
 static void HspVarComobj_Free( PVal *pval )
 {
 	//		PVALポインタの変数メモリを解放する
@@ -85,7 +72,7 @@ static void HspVarComobj_Free( PVal *pval )
 #ifdef HSP_COMOBJ_DEBUG
 			COM_DBG_MSG( "HspVarComobj_Free()\n" );
 #endif
-			int count = GetVarElememtCount( pval );
+			int count = HspVarCoreCountElems( pval );
 			ppunk = (IUnknown **)pval->pt;
 			for (int i=0; i<count; i++) {
 				ReleaseComPtr( &ppunk[i] );
@@ -111,7 +98,7 @@ static void HspVarComobj_Alloc( PVal *pval, const PVal *pval2 )
 	COM_DBG_MSG( "HspVarComobj_Alloc()\n" );
 #endif
 	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// 配列を最低 1 は確保する
-	count = GetVarElememtCount( pval );
+	count = HspVarCoreCountElems(pval);
 	size  = count * sizeof( IUnknown* );
 	ppunk = (IUnknown **)sbAlloc( size );
 	pval->mode = HSPVAR_MODE_MALLOC;

--- a/trunk/hsp3/win32gui/hspvar_variant.cpp
+++ b/trunk/hsp3/win32gui/hspvar_variant.cpp
@@ -60,18 +60,6 @@ static void *HspVarVariant_CnvCustom( const void *buffer, int flag )
 	return (void *)buffer;
 }
 
-static int GetVarElememtCount( PVal *pval )
-{
-	//		•Ï”‚Ì—v‘f”‚ðŽæ“¾‚·‚é
-	//
-	int count;
-	count = pval->len[1];
-	if ( pval->len[2] ) count *= pval->len[2];
-	if ( pval->len[3] ) count *= pval->len[3];
-	if ( pval->len[4] ) count *= pval->len[4];
-	return count;
-}
-
 
 static void HspVarVariant_Free( PVal *pval )
 {
@@ -89,7 +77,7 @@ static void HspVarVariant_Free( PVal *pval )
 
 	if ( pval->mode == HSPVAR_MODE_MALLOC ) {
 		if ( (pval->support & HSPVAR_SUPPORT_TEMPVAR) == 0 ) {
-			int count = GetVarElememtCount( pval );
+			int count = HspVarCoreCountElems(pval);
 			var = (VARIANT *)pval->pt;
 			for (int i=0; i<count; i++) {
 				VariantClear( &var[i] );
@@ -116,7 +104,7 @@ static void HspVarVariant_Alloc( PVal *pval, const PVal *pval2 )
 	COM_DBG_MSG( "HspVarVariant_Alloc()\n" );
 #endif
 	if ( pval->len[1] < 1 ) pval->len[1] = 1;		// ”z—ñ‚ðÅ’á 1 ‚ÍŠm•Û‚·‚é
-	count = GetVarElememtCount( pval );
+	count = HspVarCoreCountElems(pval);
 	size  = count * sizeof( VARIANT );
 	var = (VARIANT *)sbAlloc( size );
 	pval->mode = HSPVAR_MODE_MALLOC;


### PR DESCRIPTION
現在の実装では、配列の拡張時に毎回バッファを確保しなおしているため低速。(Θ(n) 時間かかっている。)

実際には、配列の要素数が5万程度になる場合に問題となる。(1秒近くのラグを生じる。)
### 具体例

内部で配列拡張を引き起こす `newmod`、`split` など。
## 解決案
- 拡張時に、バッファを定数倍だけ余分に広げる。
  - 2倍、1.5倍が使われることが多いようだ。後述のベンチマークによれば 1.0625 倍程度でも十分な速度がでるので、既存のコードのメモリ効率を悪化させてしまうことを考えれば、そのくらいの値でよいかも？
  - 要検討
    - 参考コラム: [2倍だけじゃない](http://www.kmonos.net/wlog/111.html#_2334100705)
- 新しい配列長のために必要なバッファサイズが確保済みであれば、バッファの再確保を行わない。
  - `HspVarProc::Alloc` を `pval == pval2` である場合に最適化する。
    - 現在の実装では、ランタイムからは `pval == pval2` でしか呼び出されていない。
## TODO
- [x] label
- [x] str
- [x] double
- [x] int
- [x] struct
- [ ] comobj - wontfix
- [ ] variant - wontfix
- [x] 適切なコード共通化
## その他

簡易ベンチマークスクリプトを作成した: [bm_array_extending.hsp](https://gist.github.com/vain0/0d9cf5591bf5b27bb295)
