### PR TITLE
``HspVarProc::Dup`` を追加

### DIFF
--- a/trunk/hsp3/hspvar_core.cpp
+++ b/trunk/hsp3/hspvar_core.cpp
@@ -130,6 +130,7 @@ void HspVarCoreRegisterType( int flag, HSPVAR_COREFUNC func )
 		if ( procs == (void **)(&p->LrI) ) break;
 		procs++;
 	}
+	p->Dup = HspVarCoreDupDefault;
 
 	//	初期化関数の呼び出し
 
@@ -169,7 +170,16 @@ void HspVarCoreDupPtr( PVal *pval, int flag, void *ptr, int size )
 }
 
 
-void HspVarCoreDup( PVal *pval, PVal *arg, APTR aptr )
+void HspVarCoreDup(PVal *pval, PVal *arg, APTR aptr)
+{
+	//		指定された変数のクローンになる
+	//
+
+	hspvarproc[arg->flag].Dup(pval, arg, aptr);
+}
+
+
+void HspVarCoreDupDefault( PVal *pval, PVal *arg, APTR aptr )
 {
 	//		指定された変数のクローンになる
 	//

--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -158,6 +158,11 @@ typedef struct
 
 	void (*RrI)( PDAT *pval, const void *val );
 	void (*LrI)( PDAT *pval, const void *val );
+
+	//		システム参照用
+	// (ver3.5～)
+	void(*Dup)(PVal *pval, PVal *arg, APTR aptr);
+
 } HspVarProc;
 
 extern HspVarProc *hspvarproc;
@@ -206,6 +211,7 @@ HspVarProc *HspVarCoreSeekProc( const char *name );
 
 //		low level support functions
 //
+void HspVarCoreDupDefault( PVal *pval, PVal *arg, APTR aptr );
 void HspVarCoreDup( PVal *pval, PVal *arg, APTR aptr );
 void HspVarCoreDupPtr( PVal *pval, int flag, void *ptr, int size );
 void HspVarCoreClear( PVal *pval, int flag );

--- a/trunk/hsp3/hspvar_struct.cpp
+++ b/trunk/hsp3/hspvar_struct.cpp
@@ -145,6 +145,14 @@ static void HspVarStruct_Set( PVal *pval, PDAT *pdat, const void *in )
 	//sbCopy( (char **)pdat, (char *)fv->ptr, fv->size );
 }
 
+// Dup
+static void HspVarStruct_Dup(PVal *pval, PVal *arg, APTR aptr) 
+{
+	PDAT *pdat = HspVarCorePtrAPTR(arg, aptr);
+	int size = arg->size - (((char *)pdat) - arg->pt);
+	HspVarCoreDupPtr(pval, arg->flag, pdat, size);
+}
+
 /*
 // INVALID
 static void HspVarStruct_Invalid( PDAT *pval, const void *val )
@@ -171,6 +179,7 @@ static void AllocBlock( PVal *pval, PDAT *pdat, int size )
 void HspVarStruct_Init( HspVarProc *p )
 {
 	p->Set = HspVarStruct_Set;
+	p->Dup = HspVarStruct_Dup;
 	p->GetPtr = HspVarStruct_GetPtr;
 //	p->Cnv = HspVarStruct_Cnv;
 //	p->CnvCustom = HspVarStruct_CnvCustom;


### PR DESCRIPTION
Issue #9 の改善案の1つ。

`HspVarProc::Dup` メンバを追加し、`dup` 命令の実装を型ごとに定義させる。
