### PR TITLE
変数に対する swap 操作の実装

### DIFF
--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1307,6 +1307,16 @@ static int cmdfunc_intcmd( int cmd )
 		break;
 		}
 
+	case 0x031:								// swaparray
+	{
+		PVal *pv[2];
+		for ( int i = 0; i < 2; ++i ) {
+			pv[i] = code_getpval();
+		}
+		HspVarCoreSwap(pv[0], pv[1]);
+		break;
+	}
+
 	default:
 		throw HSPERR_UNSUPPORTED_FUNCTION;
 	}

--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1306,7 +1306,6 @@ static int cmdfunc_intcmd( int cmd )
 		code_setva( pv, ap, HSPVAR_FLAG_INT, &result );
 		break;
 		}
-
 	case 0x031:								// swaparray
 	{
 		PVal *pv[2];
@@ -1316,7 +1315,19 @@ static int cmdfunc_intcmd( int cmd )
 		HspVarCoreSwap(pv[0], pv[1]);
 		break;
 	}
+	case 0x032:								// swapvar
+		{
+		PVal *pv[2];
+		PDAT *pdat[2];
+		for ( int i = 0; i < 2; ++i ) {
+			APTR aptr = code_getva(&pv[i]);
+			pdat[i] = HspVarCorePtrAPTR(pv[i], aptr);
+		}
+		if ( pv[0]->flag != pv[1]->flag ) throw HSPERR_TYPE_MISMATCH;
 
+		hspvarproc[pv[0]->flag].SwapVar(pv[0], pdat[0], pv[1], pdat[1]);
+		break;
+		}
 	default:
 		throw HSPERR_UNSUPPORTED_FUNCTION;
 	}

--- a/trunk/hsp3/hspvar_core.cpp
+++ b/trunk/hsp3/hspvar_core.cpp
@@ -128,7 +128,7 @@ void HspVarCoreRegisterType( int flag, HSPVAR_COREFUNC func )
 	procs = (void **)(&p->Cnv);
 	while(1) {
 		*procs = (void *)(PutInvalid);
-		if ( procs == (void **)(&p->LrI) ) break;
+		if ( procs == (void **)(&p->SwapVar) ) break;
 		procs++;
 	}
 	p->MoveAlloc = HspVarCoreMoveAllocDefault;

--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -160,9 +160,10 @@ typedef struct
 	void (*RrI)( PDAT *pval, const void *val );
 	void (*LrI)( PDAT *pval, const void *val );
 
-	//		システム参照
+	//		代入用関数(型の一致が保障されます)
 	// (ver3.X)
 	void(*MoveAlloc)(PVal *pval, PVal *pval2);
+	void(*SwapVar)(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2);
 } HspVarProc;
 
 extern HspVarProc *hspvarproc;
@@ -253,7 +254,13 @@ inline PDAT *HspVarCorePtrAPTR( PVal *pv, APTR ofs )
 	return hspvarproc[(pv)->flag].GetPtr(pv);
 }
 
-
-
+// std::swap will come in C++11
+template<typename T> T& myswap(T& l, T& r)
+{
+	T t = l;
+	l = r;
+	r = t;
+	return l;
+}
 
 #endif

--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -40,6 +40,7 @@
 #define HSPVAR_SUPPORT_USER1 0x4000				// ユーザーフラグ1
 #define HSPVAR_SUPPORT_USER2 0x8000				// ユーザーフラグ2
 
+#define HSPVAR_SUPPORT_VARATTR (HSPVAR_SUPPORT_TEMPVAR) // 変数自体がもつ属性のフラグ
 #define HSPVAR_SUPPORT_MISCTYPE (HSPVAR_SUPPORT_ARRAYOBJ)
 
 typedef void * PDAT;							// データの実態へのポインタ
@@ -158,6 +159,10 @@ typedef struct
 
 	void (*RrI)( PDAT *pval, const void *val );
 	void (*LrI)( PDAT *pval, const void *val );
+
+	//		システム参照
+	// (ver3.X)
+	void(*MoveAlloc)(PVal *pval, PVal *pval2);
 } HspVarProc;
 
 extern HspVarProc *hspvarproc;
@@ -206,6 +211,8 @@ HspVarProc *HspVarCoreSeekProc( const char *name );
 
 //		low level support functions
 //
+void HspVarCoreSwap(PVal *pval, PVal *pval2);
+void HspVarCoreMoveAllocDefault(PVal *pval1, PVal *pval2);
 void HspVarCoreDup( PVal *pval, PVal *arg, APTR aptr );
 void HspVarCoreDupPtr( PVal *pval, int flag, void *ptr, int size );
 void HspVarCoreClear( PVal *pval, int flag );

--- a/trunk/hsp3/hspvar_double.cpp
+++ b/trunk/hsp3/hspvar_double.cpp
@@ -134,6 +134,12 @@ static void HspVarDouble_Set( PVal *pval, PDAT *pdat, const void *in )
 	memcpy(pdat, in, sizeof(double));
 }
 
+// SwapVar
+static void HspVarDouble_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*GetPtr(pdat), *GetPtr(pdat2));
+}
+
 // Add
 static void HspVarDouble_AddI( PDAT *pval, const void *val )
 {
@@ -244,6 +250,7 @@ void HspVarDouble_Init( HspVarProc *p )
 	aftertype = &p->aftertype;
 
 	p->Set = HspVarDouble_Set;
+	p->SwapVar = HspVarDouble_SwapVar;
 	p->Cnv = HspVarDouble_Cnv;
 	p->GetPtr = HspVarDouble_GetPtr;
 //	p->CnvCustom = HspVarDouble_CnvCustom;

--- a/trunk/hsp3/hspvar_int.cpp
+++ b/trunk/hsp3/hspvar_int.cpp
@@ -139,6 +139,12 @@ static void HspVarInt_Set( PVal *pval, PDAT *pdat, const void *in )
 	*GetPtr(pdat) = *((int *)(in));
 }
 
+// SwapVar
+static void HspVarInt_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*GetPtr(pdat), *GetPtr(pdat2));
+}
+
 // Add
 static void HspVarInt_AddI( PDAT *pval, const void *val )
 {
@@ -259,6 +265,7 @@ static void AllocBlock( PVal *pval, PDAT *pdat, int size )
 void HspVarInt_Init( HspVarProc *p )
 {
 	p->Set = HspVarInt_Set;
+	p->SwapVar = HspVarInt_SwapVar;
 	p->Cnv = HspVarInt_Cnv;
 	p->GetPtr = HspVarInt_GetPtr;
 //	p->CnvCustom = HspVarInt_CnvCustom;

--- a/trunk/hsp3/hspvar_label.cpp
+++ b/trunk/hsp3/hspvar_label.cpp
@@ -92,6 +92,12 @@ static int HspVarLabel_GetUsing( const PDAT *pdat )
 	return ( *pdat != NULL );
 }
 
+// SwapVar
+static void HspVarLabel_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*GetPtr(pdat), *GetPtr(pdat2));
+}
+
 // Set
 static void HspVarLabel_Set( PVal *pval, PDAT *pdat, const void *in )
 {
@@ -114,6 +120,7 @@ static void AllocBlock( PVal *pval, PDAT *pdat, int size )
 void HspVarLabel_Init( HspVarProc *p )
 {
 	p->Set = HspVarLabel_Set;
+	p->SwapVar = HspVarLabel_SwapVar;
 	p->GetPtr = HspVarLabel_GetPtr;
 	p->GetSize = HspVarLabel_GetSize;
 	p->GetUsing = HspVarLabel_GetUsing;

--- a/trunk/hsp3/hspvar_str.cpp
+++ b/trunk/hsp3/hspvar_str.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "hspvar_core.h"
 #include "hsp3debug.h"
 
@@ -155,6 +156,22 @@ static void HspVarStr_Alloc( PVal *pval, const PVal *pval2 )
 	free( oldvar.master );
 }
 
+
+static void HspVarStr_MoveAlloc( PVal *pval, PVal *pval2 )
+{
+	HspVarCoreMoveAllocDefault(pval, pval2);
+
+	// STRINF::opt ‚ð“\‚è’¼‚·
+	if ( pval->mode == HSPVAR_MODE_MALLOC ) {
+		int size = GetVarSize(pval);
+		for ( int i = 0; i < (int)(size / sizeof(char*)); ++i ) {
+			char **pp = GetFlexBufPtr(pval, i);
+			sbSetOption( *pp, pp );
+		}
+	}
+}
+
+
 /*
 static void *HspVarStr_ArrayObject( PVal *pval, int *arg )
 {
@@ -260,6 +277,7 @@ void HspVarStr_Init( HspVarProc *p )
 //	p->ArrayObject = HspVarStr_ArrayObject;
 	p->Alloc = HspVarStr_Alloc;
 	p->Free = HspVarStr_Free;
+	p->MoveAlloc = HspVarStr_MoveAlloc;
 
 	p->AddI = HspVarStr_AddI;
 //	p->SubI = HspVarStr_Invalid;

--- a/trunk/hsp3/hspvar_struct.cpp
+++ b/trunk/hsp3/hspvar_struct.cpp
@@ -145,6 +145,12 @@ static void HspVarStruct_Set( PVal *pval, PDAT *pdat, const void *in )
 	//sbCopy( (char **)pdat, (char *)fv->ptr, fv->size );
 }
 
+// SwapVar
+static void HspVarStruct_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*(FlexValue *)(pdat), *(FlexValue *)(pdat2));
+}
+
 /*
 // INVALID
 static void HspVarStruct_Invalid( PDAT *pval, const void *val )
@@ -171,6 +177,7 @@ static void AllocBlock( PVal *pval, PDAT *pdat, int size )
 void HspVarStruct_Init( HspVarProc *p )
 {
 	p->Set = HspVarStruct_Set;
+	p->SwapVar = HspVarStruct_SwapVar;
 	p->GetPtr = HspVarStruct_GetPtr;
 //	p->Cnv = HspVarStruct_Cnv;
 //	p->CnvCustom = HspVarStruct_CnvCustom;

--- a/trunk/hsp3/win32gui/hspvar_comobj.cpp
+++ b/trunk/hsp3/win32gui/hspvar_comobj.cpp
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <ocidl.h>
 
 #include "../hsp3code.h"
@@ -349,6 +348,12 @@ static void HspVarComobj_Set( PVal *pval, PDAT *pdat, const void *in )
 	}
 }
 
+// SwapVar
+static void HspVarComobj_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*(IUnknown **)(pdat), *(IUnknown **)(pdat2));
+}
+
 
 static void *GetBlockSize( PVal *pval, PDAT *pdat, int *size )
 {
@@ -382,6 +387,7 @@ void HspVarComobj_Init( HspVarProc *p )
 	myproc = p;
 
 	p->Set = HspVarComobj_Set;
+	p->SwapVar = HspVarComobj_SwapVar;
 	p->Cnv = HspVarComobj_Cnv;
 	p->GetPtr = HspVarComobj_GetPtr;
 	p->CnvCustom = HspVarComobj_CnvCustom;

--- a/trunk/hsp3/win32gui/hspvar_variant.cpp
+++ b/trunk/hsp3/win32gui/hspvar_variant.cpp
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <ocidl.h>
 
 #include "../hsp3code.h"
@@ -686,6 +685,14 @@ static void HspVarVariant_Set( PVal *pval, PDAT *pdat, const void *in )
 #endif
 }
 
+
+// SwapVar
+static void HspVarVariant_SwapVar(PVal *pval, PDAT *pdat, PVal *pval2, PDAT *pdat2)
+{
+	myswap(*(VARIANT *)(pdat), *(VARIANT *)(pdat2));
+}
+
+
 static void *GetBlockSize( PVal *pval, PDAT *pdat, int *size )
 {
 	*size = pval->size - ( ((char *)pdat) - pval->pt );
@@ -704,6 +711,7 @@ void HspVarVariant_Init( HspVarProc *p )
 	myproc = p;
 
 	p->Set = HspVarVariant_Set;
+	p->SwapVar = HspVarVariant_SwapVar;
 	p->GetPtr = HspVarVariant_GetPtr;
 //	p->Cnv = HspVarVariant_Cnv;
 //	p->CnvCustom = HspVarVariant_CnvCustom;

--- a/trunk/hspcmp/hspcmd.cpp
+++ b/trunk/hspcmp/hspcmd.cpp
@@ -108,6 +108,7 @@ char 	s_rec[1]= "", *hsp_prestr[] =
 	"$02f 8 sortnote",				// (3.5)
 	"$030 8 sortget",				// (3.5)
 	"$031 8 swaparray",				// (3.X)
+	"$032 8 swapvar",				// (3.X)
 
 	//	enhanced command (ver2.2)
 

--- a/trunk/hspcmp/hspcmd.cpp
+++ b/trunk/hspcmp/hspcmd.cpp
@@ -107,6 +107,7 @@ char 	s_rec[1]= "", *hsp_prestr[] =
 	"$02e 8 sortstr",				// (3.5)
 	"$02f 8 sortnote",				// (3.5)
 	"$030 8 sortget",				// (3.5)
+	"$031 8 swaparray",				// (3.X)
 
 	//	enhanced command (ver2.2)
 


### PR DESCRIPTION
文字列やモジュール変数インスタンス、配列を扱うのに便利。
## 現状の問題
- 文字列型配列変数への挿入、除去、要素交換、要素移動などは、コピーなく行えるべき。swap があれば簡単にできる。
  - コピーには3つの問題がある。
    - 終端文字以降がコピーされない。
    - バッファが縮む。
    - 遅い。
- モジュール変数インスタンスを移動できるべき。
  - GC (参照カウントにせよ mark&sweep などにせよ) が実装されれば解決されるが、その予定はない。
  - せめて `unique_ptr` くらいには扱えて、関数に渡したり戻したりできないと、使いづらい。
## 実装メモ
- str 型の変数の sbStrOption は更新を要する。
- クローン変数をどうするか。
- 実はコピーしまくってもそれほど遅くない。
