### PR TITLE
deffunc実行時のスタックフレームの動的確保について

### DIFF
--- a/trunk/hsp3/hsp3code.cpp
+++ b/trunk/hsp3/hsp3code.cpp
@@ -269,7 +269,7 @@ static void inline code_calcop( int op )
 	if ( tflag == HSPVAR_FLAG_INT ) {
 		if ( stm2->type == HSPVAR_FLAG_INT ) {					// HSPVAR_FLAG_INT のみ高速化
 			calcprmf( stm1->ival, op, stm2->ival );				// 高速化された演算(intのみ)
-			StackDecLevel;										// stack->Pop() の代わり(高速に)
+			StackPop();
 			stm2->ival = stm1->ival;							// １段目スタックの値を入れ替える
 			return;
 		}
@@ -639,7 +639,7 @@ int code_get( void )
 			code_next();
 			break;
 		case TYPE_DNUM:
-			StackPush( type, strp(val), sizeof(double) );
+			StackPushd( *(double *)strp(val) );
 			code_next();
 			break;
 		case TYPE_STRUCT:

--- a/trunk/hsp3/stack.cpp
+++ b/trunk/hsp3/stack.cpp
@@ -74,7 +74,6 @@ void StackReset( void )
 void StackPush( int type, char *data, int size )
 {
 	STMDATA *stm;
-	double *dptr;
 	if ( stm_cur >= stm_maxptr ) throw HSPERR_STACK_OVERFLOW;
 	stm = stm_cur;
 	stm->type = type;
@@ -121,37 +120,6 @@ void *StackPushSize( int type, int size )
 void StackPushStr( char *str )
 {
 	StackPush( HSPVAR_FLAG_STR, str, (int)strlen(str)+1 );
-}
-
-void StackPushTypeVal( int type, int val, int val2 )
-{
-	STMDATA *stm;
-	int *iptr;
-//	if ( stm_cur >= stm_maxptr ) throw HSPERR_STACK_OVERFLOW;
-	stm = stm_cur;
-	stm->type = type;
-//	stm->mode = STMMODE_SELF;
-	stm->ival = val;
-	iptr = (int *)stm->itemp;
-	*iptr = val2;
-	stm_cur++;
-}
-
-void StackPushVar( void *pval, int aptr )
-{
-    STMDATA *stm;
-    //	if ( stm_cur >= stm_maxptr ) throw HSPERR_STACK_OVERFLOW;
-    stm = stm_cur;
-    stm->type = -1;         // HSPVAR_FLAG_VAR
-    //	stm->mode = STMMODE_SELF;
-    stm->pval = pval;
-    stm->ival = aptr;
-    stm_cur++;
-}
-
-void StackPushType( int type )
-{
-	StackPushTypeVal( type, 0, 0 );
 }
 
 void StackPopFree( void )

--- a/trunk/hsp3/stack.cpp
+++ b/trunk/hsp3/stack.cpp
@@ -73,29 +73,22 @@ void StackReset( void )
 
 void StackPush( int type, char *data, int size )
 {
-	STMDATA *stm;
 	if ( stm_cur >= stm_maxptr ) throw HSPERR_STACK_OVERFLOW;
-	stm = stm_cur;
-	stm->type = type;
 	switch( type ) {
 	case HSPVAR_FLAG_LABEL:
+		StackPushl(*(int *)data);
+		return;
 	case HSPVAR_FLAG_INT:
-//		stm->mode = STMMODE_SELF;
-		stm->ival = *(int *)data;
-//		stm->ptr = (char *)&(stm->ival);
-		stm_cur++;
+		StackPushi(*(int *)data);
 		return;
 	case HSPVAR_FLAG_DOUBLE:
-		//dptr = (double *)&stm->ival;
-		//*dptr = *(double *)data;
-		memcpy(&stm->ival, data, sizeof(double));
-//		stm->mode = STMMODE_SELF;
-//		stm->ptr = (char *)dptr;
-		stm_cur++;
+		StackPushd(*(double *)data);
 		return;
 	default:
 		break;
 	}
+	STMDATA *stm = stm_cur;
+	stm->type = type;
 	StackAlloc( stm, size );
 	memcpy( stm->ptr, data, size );
 	stm_cur++;

--- a/trunk/hsp3/stack.h
+++ b/trunk/hsp3/stack.h
@@ -38,9 +38,6 @@ void StackPush( int type, char *str );
 void *StackPushSize( int type, int size );
 void StackPushi( int val );
 void StackPushStr( char *str );
-void StackPushType( int type );
-void StackPushTypeVal( int type, int val, int val2 );
-void StackPushVar( void *pval, int aptr );
 void StackPop( void );
 void StackPopFree( void );
 

--- a/trunk/hsp3/stack.h
+++ b/trunk/hsp3/stack.h
@@ -25,7 +25,6 @@ typedef struct
 	short type;
 	short mode;
 	char *ptr;
-	void *pval;
 	int ival HSP_ALIGN_DOUBLE;
 	char itemp[STM_STRSIZE_DEFAULT-4];		// data area padding
 } STMDATA;


### PR DESCRIPTION
64 byteを超えるスタックフレームは `malloc` によって確保される。現在の実装では `local` 引数1つだけでこの閾値を超えてしまうので、スクリプトによってはかなり頻繁に `malloc` が呼ばれているはず。
## 案
### メモリプール

大きめのチャンク(1つあたり256 byte、など)からなるメモリプールを用意する。
### 鎖状のスタック
- スタックをいくつかのページからなる線型リストにする。
  - ページは不足するたびに確保する。
- どんなサイズのデータであってもスタック上に直接積む。
## 現状

そもそもこれは速度上のボトルネックではない気がする。
## 仮実装後の見解

鎖状のほう、ページ増加が起きない(つまり動的確保を全くしない)という非現実的な高速化を施した場合、スタックフレームが64 byteを超える呼び出しが15%ほど高速化した。10万回の呼び出しで100msぐらいということ。HSPで競プロするわけじゃあるまいし、現実的にはあまり影響なさそう。
## その他

簡単なベンチマークを作成した: [bm_call.hsp](https://gist.github.com/vain0/182846373547eb7d8f07)
