### PR TITLE
モジュール変数のメソッド

### DIFF
--- a/trunk/hsp3/hspvar_core.h
+++ b/trunk/hsp3/hspvar_core.h
@@ -247,6 +247,4 @@ inline PDAT *HspVarCorePtrAPTR( PVal *pv, APTR ofs )
 }
 
 
-
-
 #endif

--- a/trunk/hspcmp/token.cpp
+++ b/trunk/hspcmp/token.cpp
@@ -2402,28 +2402,33 @@ ppresult_t CToken::PP_Deffunc( int mode )
 		}
 
 		strcase2( word, fixname );
-		if ( i != TK_OBJ ) { SetError("invalid func name"); return PPRESULT_ERROR; }
-		i = lb->Search( fixname );if ( i != -1 ) {
-			if ( lb->GetFlag(i) != LAB_TYPE_PP_PREMODFUNC ) {
-				SetErrorSymbolOverdefined(fixname, i); return PPRESULT_ERROR;
+		if ( i == TK_OBJ ) {
+			i = lb->Search( fixname );if ( i != -1 ) {
+				if ( lb->GetFlag(i) != LAB_TYPE_PP_PREMODFUNC ) {
+					SetErrorSymbolOverdefined(fixname, i); return PPRESULT_ERROR;
+				}
+				id = i;
 			}
-			id = i;
-		}
 
-		if ( glmode ) AddModuleName( fixname );
+			if ( glmode ) AddModuleName( fixname );
+
+			if ( id == -1 ) {
+				id = lb->Regist( fixname, premode, 0 );
+				if ( glmode == 0 ) lb->SetEternal( id );
+				if ( *mod != 0 ) { lb->AddRelation( mod, id ); }		// モジュールラベルに依存を追加
+			} else {
+				lb->SetFlag( id, premode );
+			}
+		} else if ( i == TK_STRING ) {
+			//
+		} else {
+			SetError("invalid func name"); return PPRESULT_ERROR;
+		}
 
 		if ( premode == LAB_TYPE_PP_PREMODFUNC ) {
 			wrtbuf->PutStrf( "#deffunc prep %s ",fixname );
 		} else {
 			wrtbuf->PutStrf( "#deffunc %s ",fixname );
-		}
-
-		if ( id == -1 ) {
-			id = lb->Regist( fixname, premode, 0 );
-			if ( glmode == 0 ) lb->SetEternal( id );
-			if ( *mod != 0 ) { lb->AddRelation( mod, id ); }		// モジュールラベルに依存を追加
-		} else {
-			lb->SetFlag( id, premode );
 		}
 
 		if ( mode ) {

--- a/trunk/hspcmp/token.h
+++ b/trunk/hspcmp/token.h
@@ -191,6 +191,7 @@ public:
 	int PutDSStr( char *str, bool converts_to_utf8 );
 	int PutDSBuf( char *str );
 	int PutDSBuf( char *str, int size );
+	void PutDSMethods();
 	char *GetDS( int ptr );
 	void SetOT( int id, int value );
 	void PutDI( void );
@@ -450,6 +451,8 @@ private:
 	std::map<double, int> double_literal_table; // 定数プール用
 	std::map<std::string, int> string_literal_table;
 #endif
+
+	std::unordered_map<std::string, std::unordered_map<std::string, int>> methods; // モジュールクラスの名前→メソッド名→fi_index
 
 	//		for Header info
 	int hed_option;

--- a/trunk/hspcmp/win32dll/hspcmp3.vcxproj
+++ b/trunk/hspcmp/win32dll/hspcmp3.vcxproj
@@ -20,7 +20,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -51,7 +51,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;HSPCMP3_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;HSPCMP3_EXPORTS;HSPWIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
モジュール変数に「メソッド」と呼ばれる新しい形での命令・関数呼び出し方法を提供する案。
## 例

``` hsp
#module num x_

// 名前 x のメソッド(関数)を定義する
#modcfunc "x"
  return x_

// コピーコンストラクタと呼ばれるメソッドを定義する
#modinit "copy" var rhs
  x_ = rhs["x"]
  return

// 通常のコンストラクタ
#modinit int x
  x_ = x
  return
#global

// 通常のコンストラクタで初期化
newmod v1, num, 1

// コピーコンストラクタが定義されていれば、それで v2 が初期化される
v2 = v1

// メソッドの呼び出し
mes v2["x"]
```
## 実装

クラスごとに vtbl と呼ばれる表を定義する。これはメソッドの名前からメソッドの定義関数への対応を表す。
インスタンスに名前 x のメソッドが呼ばれるとき、そのインスタンスのクラスの vtbl から名前 x のメソッドの定義を探して、それを実行する。
これによりインスタンスの実行時のクラスにもとづいた多態性が実現できる。

``` hsp
#module
#deffunc push_and_mes var self, var value
  self["push"] value  // 
  mes value
  return
#global

newmod l, mc_list  // これはリスト
newmod s, mc_stack  // これはスタック

push_and_mes l, "l"
push_and_mes s", "s"
```
