### PR TITLE
マウスクリックの左右反転に対応していない問題

### DIFF
--- a/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
+++ b/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
@@ -912,8 +912,7 @@ static int cmdfunc_extcmd( int cmd )
 		p1=code_getdi(1);
 
 		if ( p1 == VK_LBUTTON || p1 == VK_RBUTTON ) {
-			static bool const swap_button = GetSystemMetrics(SM_SWAPBUTTON);
-			if ( swap_button ) { p1 ^= VK_LBUTTON ^ VK_RBUTTON; }
+			if ( GetSystemMetrics(SM_SWAPBUTTON) ) { p1 ^= VK_LBUTTON ^ VK_RBUTTON; }
 		}
 
 		if ( code_event( HSPEVENT_GETKEY, p1, 0, &p2 ) == 0 ) {
@@ -1119,12 +1118,11 @@ static int cmdfunc_extcmd( int cmd )
 				break;
 			}
 		}
-		static bool swap_button = GetSystemMetrics(SM_SWAPBUTTON);
 		static int stick_keys[] = {
 			VK_LEFT, VK_UP, VK_RIGHT, VK_DOWN, VK_SPACE, VK_RETURN,
 			VK_CONTROL, VK_ESCAPE,
-			(swap_button ? VK_RBUTTON : VK_LBUTTON),
-			(swap_button ? VK_LBUTTON : VK_RBUTTON),
+			(GetSystemMetrics(SM_SWAPBUTTON) ? VK_RBUTTON : VK_LBUTTON),
+			(GetSystemMetrics(SM_SWAPBUTTON) ? VK_LBUTTON : VK_RBUTTON),
 			VK_TAB
 		};
 

--- a/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
+++ b/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
@@ -291,7 +291,6 @@ static int chgdisp( int mode, int sx, int sy )
 	return 0;
 }
 
-
 /*------------------------------------------------------------*/
 /*
 		for polygon process interface
@@ -1114,10 +1113,15 @@ static int cmdfunc_extcmd( int cmd )
 				break;
 			}
 		}
-		static int const stick_keys[] = {
+		static bool swap_button = GetSystemMetrics(SM_SWAPBUTTON);
+		static int stick_keys[] = {
 			VK_LEFT, VK_UP, VK_RIGHT, VK_DOWN, VK_SPACE, VK_RETURN,
-			VK_CONTROL, VK_ESCAPE, VK_LBUTTON, VK_RBUTTON, VK_TAB
+			VK_CONTROL, VK_ESCAPE,
+			(swap_button ? VK_RBUTTON : VK_LBUTTON),
+			(swap_button ? VK_LBUTTON : VK_RBUTTON),
+			VK_TAB
 		};
+
 		for ( int i = 0; i < sizeof(stick_keys) / sizeof(int); i++ ) {
 			if ( GetAsyncKeyState(stick_keys[i]) & 0x8000 ) { ckey |= 1 << i; }
 		}

--- a/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
+++ b/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
@@ -910,6 +910,12 @@ static int cmdfunc_extcmd( int cmd )
 		APTR aptr;
 		aptr = code_getva( &pval );
 		p1=code_getdi(1);
+
+		if ( p1 == VK_LBUTTON || p1 == VK_RBUTTON ) {
+			static bool const swap_button = GetSystemMetrics(SM_SWAPBUTTON);
+			if ( swap_button ) { p1 ^= VK_LBUTTON ^ VK_RBUTTON; }
+		}
+
 		if ( code_event( HSPEVENT_GETKEY, p1, 0, &p2 ) == 0 ) {
 			if ( GetAsyncKeyState(p1)&0x8000 ) p2=1; else p2=0;
 		}

--- a/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
+++ b/trunk/hsp3/win32gui/hsp3gr_wingui.cpp
@@ -1114,17 +1114,13 @@ static int cmdfunc_extcmd( int cmd )
 				break;
 			}
 		}
-		if ( GetAsyncKeyState(37)&0x8000 ) ckey|=1;		// [left]
-		if ( GetAsyncKeyState(38)&0x8000 ) ckey|=2;		// [up]
-		if ( GetAsyncKeyState(39)&0x8000 ) ckey|=4;		// [right]
-		if ( GetAsyncKeyState(40)&0x8000 ) ckey|=8;		// [down]
-		if ( GetAsyncKeyState(32)&0x8000 ) ckey|=16;	// [spc]
-		if ( GetAsyncKeyState(13)&0x8000 ) ckey|=32;	// [ent]
-		if ( GetAsyncKeyState(17)&0x8000 ) ckey|=64;	// [ctrl]
-		if ( GetAsyncKeyState(27)&0x8000 ) ckey|=128;	// [esc]
-		if ( GetAsyncKeyState(1)&0x8000 )  ckey|=256;	// mouse_l
-		if ( GetAsyncKeyState(2)&0x8000 )  ckey|=512;	// mouse_r
-		if ( GetAsyncKeyState(9)&0x8000 )  ckey|=1024;	// [tab]
+		static int const stick_keys[] = {
+			VK_LEFT, VK_UP, VK_RIGHT, VK_DOWN, VK_SPACE, VK_RETURN,
+			VK_CONTROL, VK_ESCAPE, VK_LBUTTON, VK_RBUTTON, VK_TAB
+		};
+		for ( int i = 0; i < sizeof(stick_keys) / sizeof(int); i++ ) {
+			if ( GetAsyncKeyState(stick_keys[i]) & 0x8000 ) { ckey |= 1 << i; }
+		}
 		cktrg = (ckey^cklast)&ckey;
 		cklast = ckey;
 		res = cktrg|(ckey&p1);


### PR DESCRIPTION
`getkey`, `stick` がマウスクリックの左右反転に対応していない。
- `onclick` は問題ない。
- `GetSystemMetrics` を使う必要がある。
- [左利きかどうか調べるモジュール - HSPTV!掲示板](http://hsp.tv/play/pforum.php?mode=pastwch&num=18629)
- hsptv ブラウザも対応していない。
## TODO
- [x] 状態を持つ変数が2か所に分かれている。1つにまとめるべき。
- [x] 反転されているか否かのチェックは毎回行うべき？
