### PR TITLE
`limit`, `limitf` の上限・下限を省略可能にする

### DIFF
--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1517,8 +1517,8 @@ static void *reffunc_intfunc( int *type_res, int arg )
 
 	case 0x011:								// limit
 		p1 = code_geti();
-		p2 = code_geti();
-		p3 = code_geti();
+		p2 = code_getdi(INT_MIN);
+		p3 = code_getdi(INT_MAX);
 		reffunc_intfunc_ivalue = GetLimit( p1, p2, p3 );
 		break;
 

--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1676,8 +1676,8 @@ static void *reffunc_intfunc( int *type_res, int arg )
 		{
 		HSPREAL d1,d2,d3;
 		d1 = code_getd();
-		d2 = code_getd();
-		d3 = code_getd();
+		d2 = code_getdd(-INFINITY);
+		d3 = code_getdd(INFINITY);
 		if ( d1 < d2 ) d1 = d2;
 		if ( d1 > d3 ) d1 = d3;
 		reffunc_intfunc_value = d1;


### PR DESCRIPTION
`limit(_, lb, ub)` の lb, ub は、それぞれ省略時に INT_MIN, INT_MAX となるのが自然。こうしておけば、いわゆる min, max 関数 (int版) を定義しなくてもよくなって便利。

同様に、double 版の `limitf(_, lb, ub)` の lb, ub も、それぞれ -∞, ∞ を省略値とするのが自然に感じられる。
