### PR TITLE
`varptr` がバッファサイズを `strsize` に戻す

### DIFF
--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1541,6 +1541,15 @@ static void *reffunc_intfunc( int *type_res, int arg )
 		break;
 		}
 
+	case 0x0014:							// memsize
+		{
+		PVal *pval;
+		int size;
+		(void)code_getvptr(&pval, &size);
+		reffunc_intfunc_ivalue = size;
+		break;
+		}
+
 
 	// str function
 	case 0x100:								// str

--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1454,6 +1454,7 @@ static void *reffunc_intfunc( int *type_res, int arg )
 		aptr = code_getva( &pval );
 		pdat = HspVarCorePtrAPTR( pval, aptr );
 		reffunc_intfunc_ivalue = (int)(size_t)(pdat);
+		(void)HspVarCoreGetBlockSize(pval, pdat, &ctx->strsize);
 		break;
 		}
 	case 0x00d:								// varuse

--- a/trunk/hsp3/hsp3int.cpp
+++ b/trunk/hsp3/hsp3int.cpp
@@ -1541,15 +1541,6 @@ static void *reffunc_intfunc( int *type_res, int arg )
 		break;
 		}
 
-	case 0x0014:							// memsize
-		{
-		PVal *pval;
-		int size;
-		(void)code_getvptr(&pval, &size);
-		reffunc_intfunc_ivalue = size;
-		break;
-		}
-
 
 	// str function
 	case 0x100:								// str

--- a/trunk/hspcmp/hspcmd.cpp
+++ b/trunk/hspcmp/hspcmd.cpp
@@ -265,6 +265,7 @@ char 	s_rec[1]= "", *hsp_prestr[] =
 	"$011 13 limit",					// (3.0)
 	"$012 13 getease",					// (3.4)
 	"$013 13 notefind",					// (3.5)
+	"$014 13 memsize",					// (3.5)
 
 	//	3.0 string function
 	"$100 13 str",

--- a/trunk/hspcmp/hspcmd.cpp
+++ b/trunk/hspcmp/hspcmd.cpp
@@ -265,7 +265,6 @@ char 	s_rec[1]= "", *hsp_prestr[] =
 	"$011 13 limit",					// (3.0)
 	"$012 13 getease",					// (3.4)
 	"$013 13 notefind",					// (3.5)
-	"$014 13 memsize",					// (3.5)
 
 	//	3.0 string function
 	"$100 13 str",


### PR DESCRIPTION
バッファサイズを取得する関数 `memsize` を追加する。`memcpy` などのメモリ操作を行う際の手助けとなる。
